### PR TITLE
feat(localization): Option to specify in which location the request data will be displayed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genshin-kit",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "An API wrapper for fetching player data of Genshin Impact from any servers.",
   "main": "lib/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "yarn clear && tsc",
     "dev": "tsc --watch",
-    "clear": "wsl rm -rf ./lib ./dist ./src/**/dist",
+    "clear": "wsl rm -rf ./lib ./dist",
     "bump": "yarn lint && yarn build && bump",
     "lint": "eslint ./src",
     "pretty": "eslint --fix ./src"

--- a/sample/charactersFilter.js
+++ b/sample/charactersFilter.js
@@ -15,17 +15,17 @@ App.getAllCharacters(uid).then((data) => {
   )
 
   // 用角色名称查询详情
-  const diluke = Filter.name('迪卢克')
+  const diluke = Filter.name('宵宫')
   if (diluke) {
     console.log(
       'byName',
-      `玩家 ${uid} 的迪卢克`,
+      `玩家 ${uid} 的宵宫`,
       `${diluke.level}级 好感${diluke.fetter} 命座${activedConstellations(
         diluke
       )}`
     )
   } else {
-    console.log(`玩家 ${uid} 没有迪卢克`)
+    console.log(`玩家 ${uid} 没有宵宫`)
   }
 
   // 也可以用角色 id 查询

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,7 +105,7 @@ export class GenshinKit {
    * @method setServerLanguage
    * @param locale Server locale: Language in which character names, weapons, etc. will be displayed.
    */ 
-  setServerLocale(locale: 'zh-cn' | 'zh-tw' | 'de-de' | 'en-us' | 'es-es' | 'fr-fr' | 'id-id' | 'ja-jp' | 'ko-kr' | 'pt-pt' | 'ru-ru' | 'th-th' | 'vi-vn') {
+  setServerLocale(locale: 'zh-cn' | 'zh-tw' | 'de-de' | 'en-us' | 'es-es' | 'fr-fr' | 'id-id' | 'ja-jp' | 'ko-kr' | 'pt-pt' | 'ru-ru' | 'th-th' | 'vi-vn'): this {
     this.serverLocale = locale
     return this
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ export class GenshinKit {
   _cache!: AppCache
   cookie!: string
   serverType!: 'cn' | 'os'
+  serverLocale!: 'zh-cn' | 'zh-tw' | 'de-de' | 'en-us' | 'es-es' | 'fr-fr' | 'id-id' | 'ja-jp' | 'ko-kr' | 'pt-pt' | 'ru-ru' | 'th-th' | 'vi-vn'
   _getApiEndpoint: typeof _getApiEndpoint
   _hoyolabVersion!: typeof _hoyolabVersion
   _getHttpHeaders!: typeof _getHttpHeaders
@@ -60,6 +61,7 @@ export class GenshinKit {
     this._hoyolabVersion = _hoyolabVersion
     this.request = request
     this.serverType = 'cn'
+    this.serverLocale = 'zh-cn'
 
     // Alias
     this.getCharacters = this.getAllCharacters
@@ -96,6 +98,15 @@ export class GenshinKit {
     if (!['cn', 'os'].includes(type))
       throw { code: -1, message: 'No such server type' }
     this.serverType = type
+    return this
+  }
+
+  /**
+   * @method setServerLanguage
+   * @param locale Server locale: Language in which character names, weapons, etc. will be displayed.
+   */ 
+  setServerLocale(locale: 'zh-cn' | 'zh-tw' | 'de-de' | 'en-us' | 'es-es' | 'fr-fr' | 'id-id' | 'ja-jp' | 'ko-kr' | 'pt-pt' | 'ru-ru' | 'th-th' | 'vi-vn') {
+    this.serverLocale = locale
     return this
   }
 

--- a/src/module/_getDS.ts
+++ b/src/module/_getDS.ts
@@ -9,7 +9,7 @@ export function _getDS(this: any): string {
       return generateDS('6cqshh5dhw73bzxn20oexa9k516chk7s')
     case 'cn':
     default:
-      return generateDS('w5k9n3aqhoaovgw25l373ee18nsazydo')
+      return generateDS('4a8knnbk5pbjqsrudp3dq484m9axoc5g')
   }
 }
 

--- a/src/module/_getHttpHeaders.ts
+++ b/src/module/_getHttpHeaders.ts
@@ -12,6 +12,7 @@ export function _getHttpHeaders(this: any): any {
         Accept: 'application/json, text/plain, */*',
         'Accept-Encoding': 'gzip, deflate',
         'Accept-Language': 'zh-CN,en-US;q=0.8',
+        'x-rpc-language': this.serverLocale,
         'x-rpc-app_version': this._hoyolabVersion(),
         'x-rpc-client_type': '5',
         'User-Agent':

--- a/src/module/_hoyolabVersion.ts
+++ b/src/module/_hoyolabVersion.ts
@@ -4,6 +4,6 @@ export function _hoyolabVersion(this: any): string {
       return '1.5.0'
     case 'cn':
     default:
-      return '2.9.0'
+      return '2.10.1'
   }
 }


### PR DESCRIPTION
This setting will allow displaying the names of characters, cities, weapons, etc. in the specified locale, in case the user wants to receive the results in a specific language, and not only in Chinese.

I didn't put this implementation on the Chinese server because I didn't see it necessary and also I don't know if this configuration is compatible, I'm not from the Chinese region to be able to test.